### PR TITLE
Add street tree map link

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,9 +47,12 @@
 					<br><br>
 					Before Penn, I was an undergraduate at the department of <a href="https://www.cse.iitb.ac.in" target="_blank">Computer Science, Indian Institute of Technology, Bombay</a>.
 					<br><br>
-					My current research interests include formal methods, programming languages, and machine learning. 
-					
-				</h5>
+                                        My current research interests include formal methods, programming languages, and machine learning.
+
+                                        <br><br>
+                                        I also built a <a href="https://shaanvaidya.github.io/SanFranciscoStreetTreeMap/" target="_blank">street tree map of San Francisco</a>.
+
+                                </h5>
 				<hr>
 				
 				<h3 class="heading">Publications</h3>


### PR DESCRIPTION
## Summary
- mention the San Francisco street tree map on the homepage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f90664bf8833181ca1c64b21f3b69